### PR TITLE
Pequeno ajuste nos headers de autenticação com o Gitlab

### DIFF
--- a/src/main/java/br/com/uboard/services/UserService.java
+++ b/src/main/java/br/com/uboard/services/UserService.java
@@ -1,8 +1,5 @@
 package br.com.uboard.services;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +19,8 @@ public class UserService {
 	}
 
 	public UserDTO synchronizeUser(CredentialsDTO credentialsDTO) throws Exception {
-		Map<String, String> headers = new HashMap<>();
-		headers.put("Authorization", "Bearer " + credentialsDTO.getToken());
-
-		HttpEntity<Object> httpEntity = this.webClient.getHttpEntity(headers);
+		HttpEntity<Object> httpEntity = this.webClient
+				.getHttpEntity(this.webClient.getAuthorizationHeaders(credentialsDTO.getToken()));
 
 		String url = new StringBuilder().append(credentialsDTO.getAddress())
 				.append(this.webClient.getDefaultApiPrefix()).append(GitlabAPIEnum.USER.getPath()).toString();
@@ -37,6 +32,5 @@ public class UserService {
 		}
 
 		return response.getBody();
-
 	}
 }

--- a/src/main/java/br/com/uboard/services/WebClientRest.java
+++ b/src/main/java/br/com/uboard/services/WebClientRest.java
@@ -1,6 +1,7 @@
 package br.com.uboard.services;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +47,13 @@ public class WebClientRest {
 		for (Map.Entry<String, String> entry : newHeaders.entrySet()) {
 			headers.set(entry.getKey(), entry.getValue());
 		}
+
+		return headers;
+	}
+
+	public Map<String, String> getAuthorizationHeaders(String token) {
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Authorization", "Bearer " + token);
 
 		return headers;
 	}


### PR DESCRIPTION
Ajuste para disponibilizar um método para recuperar os cabeçalhos de autenticação com o Gitlab, visto que muitos métodos utilizarão deste recurso, não estava fazendo muito sentido deixá-lo implementado em cada método.